### PR TITLE
New bootstraps

### DIFF
--- a/lib/Mite/App.pm.mite.pm
+++ b/lib/Mite/App.pm.mite.pm
@@ -9,6 +9,32 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::App";
+        (
+            *after, *around, *before,        *extends, *field,
+            *has,   *param,  *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/App.pm.mite.pm
+++ b/lib/Mite/App.pm.mite.pm
@@ -11,7 +11,7 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::App";
+        my ( $SHIM, $CALLER ) = ( "Mite::Shim", "Mite::App" );
         (
             *after, *around, *before,        *extends, *field,
             *has,   *param,  *signature_for, *with
@@ -21,15 +21,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "class", @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/App/Command.pm.mite.pm
+++ b/lib/Mite/App/Command.pm.mite.pm
@@ -9,6 +9,32 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::App::Command";
+        (
+            *after, *around, *before,        *extends, *field,
+            *has,   *param,  *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/App/Command.pm.mite.pm
+++ b/lib/Mite/App/Command.pm.mite.pm
@@ -11,7 +11,8 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::App::Command";
+        my ( $SHIM, $CALLER ) =
+          ( "Mite::Shim", "Mite::App::Command" );
         (
             *after, *around, *before,        *extends, *field,
             *has,   *param,  *signature_for, *with
@@ -21,15 +22,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "class", @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/App/Command/clean.pm.mite.pm
+++ b/lib/Mite/App/Command/clean.pm.mite.pm
@@ -11,7 +11,8 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::App::Command::clean";
+        my ( $SHIM, $CALLER ) =
+          ( "Mite::Shim", "Mite::App::Command::clean" );
         (
             *after, *around, *before,        *extends, *field,
             *has,   *param,  *signature_for, *with
@@ -21,15 +22,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "class", @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/App/Command/clean.pm.mite.pm
+++ b/lib/Mite/App/Command/clean.pm.mite.pm
@@ -9,6 +9,32 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::App::Command::clean";
+        (
+            *after, *around, *before,        *extends, *field,
+            *has,   *param,  *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/App/Command/compile.pm
+++ b/lib/Mite/App/Command/compile.pm
@@ -30,7 +30,7 @@ sub execute {
 
     if ( $self->config->data->{dogfood} ) {
         $project->_module_fakeout_namespace(
-            sprintf 'A%02d::B%02d', int(rand(100)), int(rand(100))
+            $ENV{FAKEOUT_NAMESPACE} = sprintf 'A%02d::B%02d', int(69), int(71)
         );
     }
 

--- a/lib/Mite/App/Command/compile.pm
+++ b/lib/Mite/App/Command/compile.pm
@@ -30,7 +30,7 @@ sub execute {
 
     if ( $self->config->data->{dogfood} ) {
         $project->_module_fakeout_namespace(
-            $ENV{FAKEOUT_NAMESPACE} = sprintf 'A%02d::B%02d', int(69), int(71)
+            $ENV{FAKEOUT_NAMESPACE} = sprintf 'A%02d::B%02d', int(rand 100), int(rand 100)
         );
     }
 

--- a/lib/Mite/App/Command/compile.pm.mite.pm
+++ b/lib/Mite/App/Command/compile.pm.mite.pm
@@ -11,7 +11,8 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::App::Command::compile";
+        my ( $SHIM, $CALLER ) =
+          ( "Mite::Shim", "Mite::App::Command::compile" );
         (
             *after, *around, *before,        *extends, *field,
             *has,   *param,  *signature_for, *with
@@ -21,15 +22,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "class", @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/App/Command/compile.pm.mite.pm
+++ b/lib/Mite/App/Command/compile.pm.mite.pm
@@ -9,6 +9,32 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::App::Command::compile";
+        (
+            *after, *around, *before,        *extends, *field,
+            *has,   *param,  *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/App/Command/init.pm.mite.pm
+++ b/lib/Mite/App/Command/init.pm.mite.pm
@@ -9,6 +9,32 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::App::Command::init";
+        (
+            *after, *around, *before,        *extends, *field,
+            *has,   *param,  *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/App/Command/init.pm.mite.pm
+++ b/lib/Mite/App/Command/init.pm.mite.pm
@@ -11,7 +11,8 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::App::Command::init";
+        my ( $SHIM, $CALLER ) =
+          ( "Mite::Shim", "Mite::App::Command::init" );
         (
             *after, *around, *before,        *extends, *field,
             *has,   *param,  *signature_for, *with
@@ -21,15 +22,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "class", @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/App/Command/preview.pm
+++ b/lib/Mite/App/Command/preview.pm
@@ -27,12 +27,15 @@ sub execute {
 
     return 0 if $self->should_exit_quietly;
 
+    my $file = $self->kingpin_command->args->get( 'file' )->value;
+
     my $project = $self->project;
     $project->load_directory;
 
-    my $file   = $self->kingpin_command->args->get( 'file' )->value;
-    my $source = $project->source_for( $file );
+    $project->load_files( [ $file ], '.' )
+        unless $project->sources->{$file};
 
+    my $source = $project->source_for( $file );
     print $source->compile;
 
     return 0;

--- a/lib/Mite/App/Command/preview.pm.mite.pm
+++ b/lib/Mite/App/Command/preview.pm.mite.pm
@@ -9,6 +9,32 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::App::Command::preview";
+        (
+            *after, *around, *before,        *extends, *field,
+            *has,   *param,  *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/App/Command/preview.pm.mite.pm
+++ b/lib/Mite/App/Command/preview.pm.mite.pm
@@ -11,7 +11,8 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::App::Command::preview";
+        my ( $SHIM, $CALLER ) =
+          ( "Mite::Shim", "Mite::App::Command::preview" );
         (
             *after, *around, *before,        *extends, *field,
             *has,   *param,  *signature_for, *with
@@ -21,15 +22,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "class", @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/Attribute.pm.mite.pm
+++ b/lib/Mite/Attribute.pm.mite.pm
@@ -9,6 +9,32 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::Attribute";
+        (
+            *after, *around, *before,        *extends, *field,
+            *has,   *param,  *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/Attribute.pm.mite.pm
+++ b/lib/Mite/Attribute.pm.mite.pm
@@ -11,7 +11,7 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::Attribute";
+        my ( $SHIM, $CALLER ) = ( "Mite::Shim", "Mite::Attribute" );
         (
             *after, *around, *before,        *extends, *field,
             *has,   *param,  *signature_for, *with
@@ -21,15 +21,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "class", @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/Class.pm.mite.pm
+++ b/lib/Mite/Class.pm.mite.pm
@@ -11,7 +11,7 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::Class";
+        my ( $SHIM, $CALLER ) = ( "Mite::Shim", "Mite::Class" );
         (
             *after, *around, *before,        *extends, *field,
             *has,   *param,  *signature_for, *with
@@ -21,15 +21,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "class", @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/Compiled.pm.mite.pm
+++ b/lib/Mite/Compiled.pm.mite.pm
@@ -11,7 +11,7 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::Compiled";
+        my ( $SHIM, $CALLER ) = ( "Mite::Shim", "Mite::Compiled" );
         (
             *after, *around, *before,        *extends, *field,
             *has,   *param,  *signature_for, *with
@@ -21,15 +21,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "class", @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/Compiled.pm.mite.pm
+++ b/lib/Mite/Compiled.pm.mite.pm
@@ -9,6 +9,32 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::Compiled";
+        (
+            *after, *around, *before,        *extends, *field,
+            *has,   *param,  *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/Config.pm.mite.pm
+++ b/lib/Mite/Config.pm.mite.pm
@@ -9,6 +9,32 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::Config";
+        (
+            *after, *around, *before,        *extends, *field,
+            *has,   *param,  *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/Config.pm.mite.pm
+++ b/lib/Mite/Config.pm.mite.pm
@@ -11,7 +11,7 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::Config";
+        my ( $SHIM, $CALLER ) = ( "Mite::Shim", "Mite::Config" );
         (
             *after, *around, *before,        *extends, *field,
             *has,   *param,  *signature_for, *with
@@ -21,15 +21,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "class", @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/MakeMaker.pm.mite.pm
+++ b/lib/Mite/MakeMaker.pm.mite.pm
@@ -11,7 +11,7 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::MakeMaker";
+        my ( $SHIM, $CALLER ) = ( "Mite::Shim", "Mite::MakeMaker" );
         (
             *after, *around, *before,        *extends, *field,
             *has,   *param,  *signature_for, *with
@@ -21,15 +21,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "class", @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/MakeMaker.pm.mite.pm
+++ b/lib/Mite/MakeMaker.pm.mite.pm
@@ -9,6 +9,32 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::MakeMaker";
+        (
+            *after, *around, *before,        *extends, *field,
+            *has,   *param,  *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/Miteception.pm
+++ b/lib/Mite/Miteception.pm
@@ -49,13 +49,6 @@ sub load_mite_file {
 		 local @INC = ('.', @INC);
 		 require $mite_file;
 	}
-
-	'Mite::Shim'->_inject_mite_functions(
-		$caller,
-		$file,
-		( $arg{'-role'} ? 'role' : 'class' ),
-		\%arg,
-	);
 }
 
 1;

--- a/lib/Mite/Package.pm
+++ b/lib/Mite/Package.pm
@@ -33,6 +33,11 @@ has imported_functions =>
   isa           => Map[ MethodName, Str ],
   builder       => sub { {} };
 
+has imported_keywords =>
+  is            => ro,
+  isa           => Map[ MethodName, Str ],
+  builder       => sub { {} };
+
 sub kind { 'package' }
 
 sub BUILD {
@@ -137,6 +142,7 @@ sub compilation_stages {
         _compile_package
         _compile_pragmas
         _compile_uses_mite
+        _compile_imported_keywords
         _compile_imported_functions
         _compile_meta_method
     );
@@ -169,11 +175,35 @@ sub _compile_uses_mite {
     join "\n", @code;
 }
 
+sub _compile_imported_keywords {
+    my $self = shift;
+
+    my %func = %{ $self->imported_keywords or {} } or return;
+    my @keywords = sort keys %func;
+    my $keyword_slots = join q{, }, map "*$_", @keywords;
+    my $coderefs = join "\n", map "            $func{$_},", @keywords;
+
+    return sprintf <<'CODE', B::perlstring( $self->name ), $keyword_slots, $self->shim_name, $coderefs;
+# Mite keywords
+BEGIN {
+    my $CALLER = %s;
+    ( %s ) = do {
+        package %s;
+        no warnings 'redefine';
+        (
+%s
+        );
+    };
+};
+CODE
+}
+
 sub _compile_imported_functions {
     my $self = shift;
     my %func = %{ $self->imported_functions } or return;
 
     return join "\n",
+        '# Mite imports',
         'BEGIN {',
         ( $func{blessed} ? '    require Scalar::Util;' : () ),
         map(

--- a/lib/Mite/Package.pm
+++ b/lib/Mite/Package.pm
@@ -183,10 +183,10 @@ sub _compile_imported_keywords {
     my $keyword_slots = join q{, }, map "*$_", @keywords;
     my $coderefs = join "\n", map "            $func{$_},", @keywords;
 
-    return sprintf <<'CODE', B::perlstring( $self->name ), $keyword_slots, $self->shim_name, $coderefs;
+    return sprintf <<'CODE', B::perlstring( $self->shim_name ), B::perlstring( $self->name ), $keyword_slots, $self->shim_name, $coderefs;
 # Mite keywords
 BEGIN {
-    my $CALLER = %s;
+    my ( $SHIM, $CALLER ) = ( %s, %s );
     ( %s ) = do {
         package %s;
         no warnings 'redefine';

--- a/lib/Mite/Package.pm.mite.pm
+++ b/lib/Mite/Package.pm.mite.pm
@@ -11,7 +11,7 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::Package";
+        my ( $SHIM, $CALLER ) = ( "Mite::Shim", "Mite::Package" );
         (
             *after, *around, *before,        *extends, *field,
             *has,   *param,  *signature_for, *with
@@ -21,15 +21,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "class", @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/Project.pm.mite.pm
+++ b/lib/Mite/Project.pm.mite.pm
@@ -9,6 +9,32 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::Project";
+        (
+            *after, *around, *before,        *extends, *field,
+            *has,   *param,  *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/Project.pm.mite.pm
+++ b/lib/Mite/Project.pm.mite.pm
@@ -11,7 +11,7 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::Project";
+        my ( $SHIM, $CALLER ) = ( "Mite::Shim", "Mite::Project" );
         (
             *after, *around, *before,        *extends, *field,
             *has,   *param,  *signature_for, *with
@@ -21,15 +21,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "class", @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/Role.pm
+++ b/lib/Mite/Role.pm
@@ -108,7 +108,8 @@ sub __FINALIZE_APPLICATION__ {
     my $shim = %s;
     for my $modifier_rule ( @METHOD_MODIFIERS ) {
         my ( $modification, $names, $coderef ) = @$modifier_rule;
-        $shim->$modification( $target, $names, $coderef );
+        my $handler = "HANDLE_$modification";
+        $shim->$handler( $target, "class", $names, $coderef );
     }
 
     return;

--- a/lib/Mite/Role.pm.mite.pm
+++ b/lib/Mite/Role.pm.mite.pm
@@ -11,7 +11,7 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::Role";
+        my ( $SHIM, $CALLER ) = ( "Mite::Shim", "Mite::Role" );
         (
             *after, *around, *before,        *extends, *field,
             *has,   *param,  *signature_for, *with
@@ -21,15 +21,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "class", @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/Role.pm.mite.pm
+++ b/lib/Mite/Role.pm.mite.pm
@@ -9,6 +9,32 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::Role";
+        (
+            *after, *around, *before,        *extends, *field,
+            *has,   *param,  *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;
@@ -154,6 +180,53 @@
               or croak "Type check failed in constructor: %s should be %s",
               "imported_functions", "Map[MethodName,Str]";
             $self->{"imported_functions"} = $value;
+        };
+
+        # Attribute imported_keywords (type: Map[MethodName,Str])
+        # has declaration, file lib/Mite/Package.pm, line 39
+        do {
+            my $value =
+              exists( $args->{"imported_keywords"} )
+              ? $args->{"imported_keywords"}
+              : $self->_build_imported_keywords;
+            do {
+
+                package Mite::Shim;
+                ( ref($value) eq 'HASH' ) and do {
+                    my $ok = 1;
+                    for my $v ( values %{$value} ) {
+                        ( $ok = 0, last ) unless do {
+
+                            package Mite::Shim;
+                            defined($v) and do {
+                                ref( \$v ) eq 'SCALAR'
+                                  or ref( \( my $val = $v ) ) eq 'SCALAR';
+                            }
+                        }
+                    };
+                    for my $k ( keys %{$value} ) {
+                        ( $ok = 0, last )
+                          unless (
+                            (
+                                do {
+
+                                    package Mite::Shim;
+                                    defined($k) and do {
+                                        ref( \$k ) eq 'SCALAR'
+                                          or ref( \( my $val = $k ) ) eq
+                                          'SCALAR';
+                                    }
+                                }
+                            )
+                            && ( do { local $_ = $k; /\A[^\W0-9]\w*\z/ } )
+                          );
+                    };
+                    $ok;
+                }
+              }
+              or croak "Type check failed in constructor: %s should be %s",
+              "imported_keywords", "Map[MethodName,Str]";
+            $self->{"imported_keywords"} = $value;
         };
 
         # Attribute attributes (type: HashRef[Mite::Attribute])
@@ -350,7 +423,7 @@
 
         # Unrecognized parameters
         my @unknown = grep not(
-/\A(?:attributes|imported_functions|method_signatures|name|r(?:equired_methods|ole(?:_args|s))|s(?:him_name|ource))\z/
+/\A(?:attributes|imported_(?:functions|keywords)|method_signatures|name|r(?:equired_methods|ole(?:_args|s))|s(?:him_name|ource))\z/
         ), keys %{$args};
         @unknown
           and croak(

--- a/lib/Mite/Role/Tiny.pm.mite.pm
+++ b/lib/Mite/Role/Tiny.pm.mite.pm
@@ -11,7 +11,7 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::Role::Tiny";
+        my ( $SHIM, $CALLER ) = ( "Mite::Shim", "Mite::Role::Tiny" );
         (
             *after, *around, *before,        *extends, *field,
             *has,   *param,  *signature_for, *with
@@ -21,15 +21,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "class", @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/Role/Tiny.pm.mite.pm
+++ b/lib/Mite/Role/Tiny.pm.mite.pm
@@ -9,6 +9,32 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::Role::Tiny";
+        (
+            *after, *around, *before,        *extends, *field,
+            *has,   *param,  *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/Shim.pm
+++ b/lib/Mite/Shim.pm
@@ -179,7 +179,7 @@ sub HANDLE_has {
 {
     my $_kind = sub {
         no strict 'refs';
-        ${ shift . '::USES_MITE' } =~ /role/i ? 'role' : 'class';
+        ${ shift() . '::USES_MITE' } =~ /role/i ? 'role' : 'class';
     };
 
     sub _get_orig_method {

--- a/lib/Mite/Shim.pm
+++ b/lib/Mite/Shim.pm
@@ -286,10 +286,9 @@ AROUND
 # Usage: $me, $caller, $caller_kind, @signature_for_args
 sub HANDLE_signature_for {
     no strict 'refs';
-    my ( $me, $caller, $kind, $name ) = ( @_ % 2 == 0 ) ? @_ : ( $_[0], $_[1], undef, $_[2] );
-    $kind //= do { no strict 'refs'; local $_ = ${"$caller\::USES_MITE"}; s/Mite:://; lc($_) };
+    my ( $me, $caller, $kind, $name ) = @_;
     $name =~ s/^\+//;
-    $me->around( $caller, $kind, $name, ${"$caller\::SIGNATURE_FOR"}{$name} );
+    $me->HANDLE_around( $caller, $kind, $name, ${"$caller\::SIGNATURE_FOR"}{$name} );
     return;
 }
 

--- a/lib/Mite/Shim.pm
+++ b/lib/Mite/Shim.pm
@@ -1,11 +1,24 @@
+# NOTE: Since the intention is to ship this file with a project, this file
+# cannot have any non-core dependencies.
 use 5.008001;
 use strict;
 use warnings;
 
-# NOTE: Since the intention is to ship this file with a project, this file
-# cannot have any non-core dependencies.
-
 package Mite::Shim;
+
+if ( $] < 5.009005 ) {
+    require MRO::Compat;
+}
+else {
+    require mro;
+}
+
+defined ${^GLOBAL_PHASE}
+or eval { require Devel::GlobalDestruction; 1 }
+or do {
+    carp( "WARNING: Devel::GlobalDestruction recommended!" );
+    *Devel::GlobalDestruction::in_global_destruction = sub { undef; };
+};
 
 # Constants
 sub true  () { !!1 }
@@ -16,6 +29,14 @@ sub rwp   () { 'rwp' }
 sub lazy  () { 'lazy' }
 sub bare  () { 'bare' }
 
+# More complicated constants
+BEGIN {
+    my @bool = ( \&false, \&true );
+    *_HAS_AUTOCLEAN = $bool[ 0+!! eval { require namespace::autoclean } ];
+    *STRICT         = $bool[ 0+!! ( $ENV{PERL_STRICT} || $ENV{EXTENDED_TESTING} || $ENV{AUTHOR_TESTING} || $ENV{RELEASE_TESTING} ) ];
+};
+
+# Exportable error handlers
 sub _error_handler {
     my ( $func, $message, @args ) = @_;
     if ( @args ) {
@@ -35,26 +56,7 @@ sub carp    { unshift @_, 'carp'   ; goto \&_error_handler }
 sub croak   { unshift @_, 'croak'  ; goto \&_error_handler }
 sub confess { unshift @_, 'confess'; goto \&_error_handler }
 
-BEGIN {
-    my @bool = ( \&false, \&true );
-    *_HAS_AUTOCLEAN = $bool[ 0+!! eval { require namespace::autoclean } ];
-    *STRICT         = $bool[ 0+!! ( $ENV{PERL_STRICT} || $ENV{EXTENDED_TESTING} || $ENV{AUTHOR_TESTING} || $ENV{RELEASE_TESTING} ) ];
-};
-
-if ( $] < 5.009005 ) {
-    require MRO::Compat;
-}
-else {
-    require mro;
-}
-
-defined ${^GLOBAL_PHASE}
-or eval { require Devel::GlobalDestruction; 1 }
-or do {
-    carp( "WARNING: Devel::GlobalDestruction recommended!" );
-    *Devel::GlobalDestruction::in_global_destruction = sub { undef; };
-};
-
+# Exportable guard function
 {
     no strict 'refs';
     my $GUARD_PACKAGE = __PACKAGE__ . '::Guard';
@@ -63,12 +65,6 @@ or do {
     *{"$GUARD_PACKAGE\::dismiss"} = sub {                 $_[0][0] = true };
     *{"$GUARD_PACKAGE\::peek"}    = sub { $_[0][2] };
     *guard = sub (&) { bless [ 0, @_ ] => $GUARD_PACKAGE };
-}
-
-sub parse_mm_args {
-    my $coderef = pop;
-    my $names   = [ map { ref($_) ? @$_ : $_ } @_ ];
-    ( $names, $coderef );
 }
 
 sub _is_compiling {
@@ -107,20 +103,206 @@ sub import {
             local @INC = ('.', @INC);
             require $mite_file;
         }
-
-        $class->_inject_mite_functions( $caller, $file, $kind, \%arg );
     }
 
     if ( _HAS_AUTOCLEAN and not $arg{'-unclean'} ) {
         'namespace::autoclean'->import( -cleanee => $caller );
     }
+
+    ## Bootstrapping
+    #$class->_inject_mite_functions( $caller, $file, $kind, \%arg );
 }
+
+{
+    my ( $cb_before, $cb_after );
+    sub _finalize_application_roletiny {
+        my ( $class, $role, $caller, $args ) = @_;
+        if ( $INC{'Role/Hooks.pm'} ) {
+            $cb_before ||= \%Role::Hooks::CALLBACKS_BEFORE_APPLY;
+            $cb_after  ||= \%Role::Hooks::CALLBACKS_AFTER_APPLY;
+        }
+        if ( $cb_before ) {
+            $_->( $role, $caller ) for @{ $cb_before->{$role} || [] };
+        }
+        'Role::Tiny'->_check_requires( $caller, $role );
+        my $info = $Role::Tiny::INFO{$role};
+        for ( @{ $info->{modifiers} || [] } ) {
+            my @args = @$_;
+            my $kind = shift @args;
+            $class->$kind( $caller, @args );
+        }
+        if ( $cb_after ) {
+            $_->( $role, $caller ) for @{ $cb_after->{$role} || [] };
+        }
+        return;
+    }
+
+    # Usage: $me, $caller, @with_args
+    sub HANDLE_with {
+        my ( $me, $caller ) = ( shift, shift );
+        while ( @_ ) {
+            my $role = shift;
+            my $args = ref($_[0]) ? shift : undef;
+            if ( $INC{'Role/Tiny.pm'} and 'Role::Tiny'->is_role( $role ) ) {
+                $me->_finalize_application_roletiny( $role, $caller, $args );
+            }
+            else {
+                $role->__FINALIZE_APPLICATION__( $caller, $args );
+            }
+        }
+        return;
+    }
+}
+
+# Usage: $me, $caller, $keyword, @has_args
+sub HANDLE_has {
+    my ( $me, $caller, $keyword, $names ) = ( shift, shift, shift, shift );
+    if ( @_ % 2 ) {
+        my $default = shift;
+        unshift @_, ( 'CODE' eq ref( $default ) )
+            ? ( is => lazy, builder => $default )
+            : ( is => ro, default => $default );
+    }
+    my %spec = @_;
+    my $code;
+    no strict 'refs';
+    for my $name ( ref($names) ? @$names : $names ) {
+        $name =~ s/^\+//;
+        'CODE' eq ref( $code = $spec{default} )
+            and ${"$caller\::__$name\_DEFAULT__"} = $code;
+        'CODE' eq ref( $code = $spec{builder} )
+           and *{"$caller\::_build_$name"} = $code;
+        'CODE' eq ref( $code = $spec{trigger} )
+           and *{"$caller\::_trigger_$name"} = $code;
+       'CODE' eq ref( $code = $spec{clone} )
+           and *{"$caller\::_clone_$name"} = $code;
+    }
+    return;
+}
+
+{
+    sub _get_orig_method {
+        my ( $caller, $name ) = @_;
+        my $orig = $caller->can( $name );
+        return $orig if $orig;
+        croak "Cannot modify method $name in $caller: no such method";
+    }
+
+    sub _parse_mm_args {
+        my $coderef = pop;
+        my $names   = [ map { ref($_) ? @$_ : $_ } @_ ];
+        ( $names, $coderef );
+    }
+
+    # Usage: $me, $caller, $caller_kind, @before_args
+    sub HANDLE_before {
+        my ( $me, $caller, $kind ) = ( shift, shift, shift );
+        my ( $names, $coderef ) = &_parse_mm_args;
+        if ( $kind eq 'role' ) {
+            no strict 'refs';
+            push @{"$caller\::METHOD_MODIFIERS"},
+                [ before => $names, $coderef ];
+            return;
+        }
+        for my $name ( @$names ) {
+            my $orig = _get_orig_method( $caller, $name );
+            local $@;
+            eval <<"BEFORE" or die $@;
+                package $caller;
+                no warnings 'redefine';
+                sub $name {
+                    \$coderef->( \@_ );
+                    \$orig->( \@_ );
+                }
+                1;
+BEFORE
+        }
+        return;
+    }
+
+    # Usage: $me, $caller, $caller_kind, @after_args
+    sub HANDLE_after {
+        my ( $me, $caller, $kind ) = ( shift, shift, shift );
+        my ( $names, $coderef ) = &_parse_mm_args;
+        if ( $kind eq 'role' ) {
+            no strict 'refs';
+            push @{"$caller\::METHOD_MODIFIERS"},
+                [ after => $names, $coderef ];
+            return;
+        }
+        for my $name ( @$names ) {
+            my $orig = _get_orig_method( $caller, $name );
+            local $@;
+            eval <<"AFTER" or die $@;
+                package $caller;
+                no warnings 'redefine';
+                sub $name {
+                    my \@r;
+                    if ( wantarray ) {
+                        \@r = \$orig->( \@_ );
+                    }
+                    elsif ( defined wantarray ) {
+                        \@r = scalar \$orig->( \@_ );
+                    }
+                    else {
+                        \$orig->( \@_ );
+                        1;
+                    }
+                    \$coderef->( \@_ );
+                    wantarray ? \@r : \$r[0];
+                }
+                1;
+AFTER
+        }
+        return;
+    }
+
+    # Usage: $me, $caller, $caller_kind, @around_args
+    sub HANDLE_around {
+        my ( $me, $caller, $kind ) = ( shift, shift, shift );
+        my ( $names, $coderef ) = &_parse_mm_args;
+        if ( $kind eq 'role' ) {
+            no strict 'refs';
+            push @{"$caller\::METHOD_MODIFIERS"},
+                [ around => $names, $coderef ];
+            return;
+        }
+        for my $name ( @$names ) {
+            my $orig = _get_orig_method( $caller, $name );
+            local $@;
+            eval <<"AROUND" or die $@;
+                package $caller;
+                no warnings 'redefine';
+                sub $name {
+                    \$coderef->( \$orig, \@_ );
+                }
+                1;
+AROUND
+        }
+        return;
+    }
+}
+
+# Usage: $me, $caller, $caller_kind, @signature_for_args
+sub HANDLE_signature_for {
+    no strict 'refs';
+    my ( $me, $caller, $kind, $name ) = ( @_ % 2 == 0 ) ? @_ : ( $_[0], $_[1], undef, $_[2] );
+    $kind //= do { no strict 'refs'; local $_ = ${"$caller\::USES_MITE"}; s/Mite:://; lc($_) };
+    $name =~ s/^\+//;
+    $me->around( $caller, $kind, $name, ${"$caller\::SIGNATURE_FOR"}{$name} );
+    return;
+}
+
+## Bootstrapping
+
+*parse_mm_args = \&_parse_mm_args;
 
 sub _inject_mite_functions {
     my ( $class, $caller, $file, $kind, $arg ) = ( shift, @_ );
     my $requested = sub { $arg->{$_[0]} ? true : $arg->{'!'.$_[0]} ? false : $arg->{'-all'} ? true : $_[1]; };
 
     no strict 'refs';
+    no warnings 'redefine';
     my $has = $class->_make_has( $caller, $file, $kind );
     *{"$caller\::has"}   = $has if $requested->( has   => true  );
     *{"$caller\::param"} = $has if $requested->( param => false );
@@ -212,36 +394,6 @@ sub _make_with {
         }
         return;
     };
-}
-
-{
-    my ( $cb_before, $cb_after );
-    sub _finalize_application_roletiny {
-        my ( $class, $role, $caller, $args ) = @_;
-
-        if ( $INC{'Role/Hooks.pm'} ) {
-            $cb_before ||= \%Role::Hooks::CALLBACKS_BEFORE_APPLY;
-            $cb_after  ||= \%Role::Hooks::CALLBACKS_AFTER_APPLY;
-        }
-        if ( $cb_before ) {
-            $_->( $role, $caller ) for @{ $cb_before->{$role} || [] };
-        }
-
-        'Role::Tiny'->_check_requires( $caller, $role );
-
-        my $info = $Role::Tiny::INFO{$role};
-        for ( @{ $info->{modifiers} || [] } ) {
-            my @args = @$_;
-            my $kind = shift @args;
-            $class->$kind( $caller, @args );
-        }
-
-        if ( $cb_after ) {
-            $_->( $role, $caller ) for @{ $cb_after->{$role} || [] };
-        }
-
-        return;
-    }
 }
 
 {

--- a/lib/Mite/Signature.pm.mite.pm
+++ b/lib/Mite/Signature.pm.mite.pm
@@ -9,6 +9,32 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::Signature";
+        (
+            *after, *around, *before,        *extends, *field,
+            *has,   *param,  *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/Signature.pm.mite.pm
+++ b/lib/Mite/Signature.pm.mite.pm
@@ -11,7 +11,7 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::Signature";
+        my ( $SHIM, $CALLER ) = ( "Mite::Shim", "Mite::Signature" );
         (
             *after, *around, *before,        *extends, *field,
             *has,   *param,  *signature_for, *with
@@ -21,15 +21,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "class", @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/Source.pm.mite.pm
+++ b/lib/Mite/Source.pm.mite.pm
@@ -9,6 +9,32 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::Source";
+        (
+            *after, *around, *before,        *extends, *field,
+            *has,   *param,  *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/Source.pm.mite.pm
+++ b/lib/Mite/Source.pm.mite.pm
@@ -11,7 +11,7 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::Source";
+        my ( $SHIM, $CALLER ) = ( "Mite::Shim", "Mite::Source" );
         (
             *after, *around, *before,        *extends, *field,
             *has,   *param,  *signature_for, *with
@@ -21,15 +21,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "class", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "class", @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/Trait/HasAttributes.pm
+++ b/lib/Mite/Trait/HasAttributes.pm
@@ -124,7 +124,7 @@ before inject_mite_functions => sub {
 
         *{ $package .'::has' } = $has;
 
-        $self->imported_keywords->{has} = 'sub { __PACKAGE__->HANDLE_has( $CALLER, has => @_ ) }';
+        $self->imported_keywords->{has} = 'sub { $SHIM->HANDLE_has( $CALLER, has => @_ ) }';
     }
 
     if ( $requested->( 'param', false ) ) {
@@ -137,7 +137,7 @@ before inject_mite_functions => sub {
             $has->( $names, %spec );
         };
 
-        $self->imported_keywords->{param} = 'sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) }';
+        $self->imported_keywords->{param} = 'sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) }';
     }
 
     if ( $requested->( 'field', false ) ) {
@@ -153,7 +153,7 @@ before inject_mite_functions => sub {
             $has->( $names, %spec );
         };
 
-        $self->imported_keywords->{field} = 'sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) }';
+        $self->imported_keywords->{field} = 'sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) }';
     }
 };
 

--- a/lib/Mite/Trait/HasAttributes.pm.mite.pm
+++ b/lib/Mite/Trait/HasAttributes.pm.mite.pm
@@ -11,7 +11,8 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::Trait::HasAttributes";
+        my ( $SHIM, $CALLER ) =
+          ( "Mite::Shim", "Mite::Trait::HasAttributes" );
         (
             *after,    *around,        *before,
             *field,    *has,           *param,
@@ -22,15 +23,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/Trait/HasAttributes.pm.mite.pm
+++ b/lib/Mite/Trait/HasAttributes.pm.mite.pm
@@ -176,7 +176,8 @@
         my $shim = "Mite::Shim";
         for my $modifier_rule (@METHOD_MODIFIERS) {
             my ( $modification, $names, $coderef ) = @$modifier_rule;
-            $shim->$modification( $target, $names, $coderef );
+            my $handler = "HANDLE_$modification";
+            $shim->$handler( $target, "class", $names, $coderef );
         }
 
         return;

--- a/lib/Mite/Trait/HasAttributes.pm.mite.pm
+++ b/lib/Mite/Trait/HasAttributes.pm.mite.pm
@@ -9,6 +9,33 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::Trait::HasAttributes";
+        (
+            *after,    *around,        *before,
+            *field,    *has,           *param,
+            *requires, *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/Trait/HasConstructor.pm.mite.pm
+++ b/lib/Mite/Trait/HasConstructor.pm.mite.pm
@@ -11,7 +11,8 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::Trait::HasConstructor";
+        my ( $SHIM, $CALLER ) =
+          ( "Mite::Shim", "Mite::Trait::HasConstructor" );
         (
             *after,    *around,        *before,
             *field,    *has,           *param,
@@ -22,15 +23,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/Trait/HasConstructor.pm.mite.pm
+++ b/lib/Mite/Trait/HasConstructor.pm.mite.pm
@@ -9,6 +9,33 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::Trait::HasConstructor";
+        (
+            *after,    *around,        *before,
+            *field,    *has,           *param,
+            *requires, *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/Trait/HasConstructor.pm.mite.pm
+++ b/lib/Mite/Trait/HasConstructor.pm.mite.pm
@@ -121,7 +121,8 @@
         my $shim = "Mite::Shim";
         for my $modifier_rule (@METHOD_MODIFIERS) {
             my ( $modification, $names, $coderef ) = @$modifier_rule;
-            $shim->$modification( $target, $names, $coderef );
+            my $handler = "HANDLE_$modification";
+            $shim->$handler( $target, "class", $names, $coderef );
         }
 
         return;

--- a/lib/Mite/Trait/HasDestructor.pm.mite.pm
+++ b/lib/Mite/Trait/HasDestructor.pm.mite.pm
@@ -9,6 +9,33 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::Trait::HasDestructor";
+        (
+            *after,    *around,        *before,
+            *field,    *has,           *param,
+            *requires, *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/Trait/HasDestructor.pm.mite.pm
+++ b/lib/Mite/Trait/HasDestructor.pm.mite.pm
@@ -11,7 +11,8 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::Trait::HasDestructor";
+        my ( $SHIM, $CALLER ) =
+          ( "Mite::Shim", "Mite::Trait::HasDestructor" );
         (
             *after,    *around,        *before,
             *field,    *has,           *param,
@@ -22,15 +23,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/Trait/HasDestructor.pm.mite.pm
+++ b/lib/Mite/Trait/HasDestructor.pm.mite.pm
@@ -121,7 +121,8 @@
         my $shim = "Mite::Shim";
         for my $modifier_rule (@METHOD_MODIFIERS) {
             my ( $modification, $names, $coderef ) = @$modifier_rule;
-            $shim->$modification( $target, $names, $coderef );
+            my $handler = "HANDLE_$modification";
+            $shim->$handler( $target, "class", $names, $coderef );
         }
 
         return;

--- a/lib/Mite/Trait/HasMOP.pm.mite.pm
+++ b/lib/Mite/Trait/HasMOP.pm.mite.pm
@@ -120,7 +120,8 @@
         my $shim = "Mite::Shim";
         for my $modifier_rule (@METHOD_MODIFIERS) {
             my ( $modification, $names, $coderef ) = @$modifier_rule;
-            $shim->$modification( $target, $names, $coderef );
+            my $handler = "HANDLE_$modification";
+            $shim->$handler( $target, "class", $names, $coderef );
         }
 
         return;

--- a/lib/Mite/Trait/HasMOP.pm.mite.pm
+++ b/lib/Mite/Trait/HasMOP.pm.mite.pm
@@ -11,7 +11,8 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::Trait::HasMOP";
+        my ( $SHIM, $CALLER ) =
+          ( "Mite::Shim", "Mite::Trait::HasMOP" );
         (
             *after,    *around,        *before,
             *field,    *has,           *param,
@@ -22,15 +23,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/Trait/HasMOP.pm.mite.pm
+++ b/lib/Mite/Trait/HasMOP.pm.mite.pm
@@ -9,6 +9,33 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::Trait::HasMOP";
+        (
+            *after,    *around,        *before,
+            *field,    *has,           *param,
+            *requires, *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/Trait/HasMethods.pm
+++ b/lib/Mite/Trait/HasMethods.pm
@@ -100,7 +100,9 @@ before inject_mite_functions => sub {
             return;
         };
 
-        $self->imported_keywords->{signature_for} = 'sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) }';
+        $self->imported_keywords->{signature_for} =
+            sprintf 'sub { $SHIM->HANDLE_signature_for( $CALLER, %s, @_ ) }',
+            B::perlstring( $kind );
     }
 
     for my $modifier ( qw( before after around ) ) {
@@ -118,7 +120,7 @@ before inject_mite_functions => sub {
         };
 
         $self->imported_keywords->{$modifier} =
-            sprintf 'sub { __PACKAGE__->HANDLE_%s( $CALLER, %s, @_ ) }',
+            sprintf 'sub { $SHIM->HANDLE_%s( $CALLER, %s, @_ ) }',
             $modifier, B::perlstring( $kind );
 
     }

--- a/lib/Mite/Trait/HasMethods.pm.mite.pm
+++ b/lib/Mite/Trait/HasMethods.pm.mite.pm
@@ -9,6 +9,33 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::Trait::HasMethods";
+        (
+            *after,    *around,        *before,
+            *field,    *has,           *param,
+            *requires, *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/Trait/HasMethods.pm.mite.pm
+++ b/lib/Mite/Trait/HasMethods.pm.mite.pm
@@ -121,7 +121,8 @@
         my $shim = "Mite::Shim";
         for my $modifier_rule (@METHOD_MODIFIERS) {
             my ( $modification, $names, $coderef ) = @$modifier_rule;
-            $shim->$modification( $target, $names, $coderef );
+            my $handler = "HANDLE_$modification";
+            $shim->$handler( $target, "class", $names, $coderef );
         }
 
         return;

--- a/lib/Mite/Trait/HasMethods.pm.mite.pm
+++ b/lib/Mite/Trait/HasMethods.pm.mite.pm
@@ -11,7 +11,8 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::Trait::HasMethods";
+        my ( $SHIM, $CALLER ) =
+          ( "Mite::Shim", "Mite::Trait::HasMethods" );
         (
             *after,    *around,        *before,
             *field,    *has,           *param,
@@ -22,15 +23,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/Trait/HasRequiredMethods.pm
+++ b/lib/Mite/Trait/HasRequiredMethods.pm
@@ -30,10 +30,15 @@ before inject_mite_functions => sub {
 
     no strict 'refs';
 
-    *{ $package .'::requires' } = sub {
-        $self->add_required_methods( @_ );
-        return;
-    } if $requested->( 'requires', 1 );
+    if ( $requested->( 'requires', 1 ) ) {
+
+        *{ $package .'::requires' } = sub {
+            $self->add_required_methods( @_ );
+            return;
+        };
+
+        $self->imported_keywords->{requires} = 'sub {}';
+    }
 };
 
 around _compile_mop_required_methods => sub {

--- a/lib/Mite/Trait/HasRequiredMethods.pm.mite.pm
+++ b/lib/Mite/Trait/HasRequiredMethods.pm.mite.pm
@@ -11,7 +11,8 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::Trait::HasRequiredMethods";
+        my ( $SHIM, $CALLER ) =
+          ( "Mite::Shim", "Mite::Trait::HasRequiredMethods" );
         (
             *after,    *around,        *before,
             *field,    *has,           *param,
@@ -22,15 +23,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/Trait/HasRequiredMethods.pm.mite.pm
+++ b/lib/Mite/Trait/HasRequiredMethods.pm.mite.pm
@@ -121,7 +121,8 @@
         my $shim = "Mite::Shim";
         for my $modifier_rule (@METHOD_MODIFIERS) {
             my ( $modification, $names, $coderef ) = @$modifier_rule;
-            $shim->$modification( $target, $names, $coderef );
+            my $handler = "HANDLE_$modification";
+            $shim->$handler( $target, "class", $names, $coderef );
         }
 
         return;

--- a/lib/Mite/Trait/HasRequiredMethods.pm.mite.pm
+++ b/lib/Mite/Trait/HasRequiredMethods.pm.mite.pm
@@ -9,6 +9,33 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::Trait::HasRequiredMethods";
+        (
+            *after,    *around,        *before,
+            *field,    *has,           *param,
+            *requires, *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/Trait/HasRoles.pm
+++ b/lib/Mite/Trait/HasRoles.pm
@@ -162,7 +162,7 @@ before inject_mite_functions => sub {
             );
         };
 
-        $self->imported_keywords->{with} = 'sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) }';
+        $self->imported_keywords->{with} = 'sub { $SHIM->HANDLE_with( $CALLER, @_ ) }';
     }
 };
 

--- a/lib/Mite/Trait/HasRoles.pm
+++ b/lib/Mite/Trait/HasRoles.pm
@@ -152,13 +152,18 @@ before inject_mite_functions => sub {
 
     no strict 'refs';
 
-    *{ $package .'::with' } = sub {
-        return $self->handle_with_keyword(
-            defined( $fake_ns )
-                ? ( map Str->check($_) ? "$fake_ns\::$_" : $_, @_ )
-                : @_
-        );
-    } if $requested->( 'with', 1 );
+    if ( $requested->( 'with', 1 ) ) {
+
+        *{ $package .'::with' } = sub {
+            return $self->handle_with_keyword(
+                defined( $fake_ns )
+                    ? ( map Str->check($_) ? "$fake_ns\::$_" : $_, @_ )
+                    : @_
+            );
+        };
+
+        $self->imported_keywords->{with} = 'sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) }';
+    }
 };
 
 around compilation_stages => sub {

--- a/lib/Mite/Trait/HasRoles.pm.mite.pm
+++ b/lib/Mite/Trait/HasRoles.pm.mite.pm
@@ -9,6 +9,33 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::Trait::HasRoles";
+        (
+            *after,    *around,        *before,
+            *field,    *has,           *param,
+            *requires, *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/Trait/HasRoles.pm.mite.pm
+++ b/lib/Mite/Trait/HasRoles.pm.mite.pm
@@ -11,7 +11,8 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::Trait::HasRoles";
+        my ( $SHIM, $CALLER ) =
+          ( "Mite::Shim", "Mite::Trait::HasRoles" );
         (
             *after,    *around,        *before,
             *field,    *has,           *param,
@@ -22,15 +23,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/Trait/HasRoles.pm.mite.pm
+++ b/lib/Mite/Trait/HasRoles.pm.mite.pm
@@ -121,7 +121,8 @@
         my $shim = "Mite::Shim";
         for my $modifier_rule (@METHOD_MODIFIERS) {
             my ( $modification, $names, $coderef ) = @$modifier_rule;
-            $shim->$modification( $target, $names, $coderef );
+            my $handler = "HANDLE_$modification";
+            $shim->$handler( $target, "class", $names, $coderef );
         }
 
         return;

--- a/lib/Mite/Trait/HasSuperclasses.pm
+++ b/lib/Mite/Trait/HasSuperclasses.pm
@@ -134,19 +134,24 @@ before inject_mite_functions => sub {
 
     no strict 'refs';
 
-    *{ $package .'::extends' } = sub {
-        return $self->handle_extends_keyword(
-            defined( $fake_ns )
-                ? map Str->check($_) ? "$fake_ns\::$_" : $_, @_
-                : @_
-        );
-    } if $requested->( 'extends', 1 );
+    if ( $requested->( 'extends', 1 ) ) {
+
+        *{ $package .'::extends' } = sub {
+            return $self->handle_extends_keyword(
+                defined( $fake_ns )
+                    ? map Str->check($_) ? "$fake_ns\::$_" : $_, @_
+                    : @_
+            );
+        };
+
+        $self->imported_keywords->{'extends'} = 'sub {}';
+    }
 };
 
 around compilation_stages => sub {
     my ( $next, $self ) = ( shift, shift );
     my @stages = $self->$next( @_ );
-    push @stages, '_compile_extends';
+    push @stages, qw( _compile_extends );
     return @stages;
 };
 

--- a/lib/Mite/Trait/HasSuperclasses.pm.mite.pm
+++ b/lib/Mite/Trait/HasSuperclasses.pm.mite.pm
@@ -11,7 +11,8 @@
 
     # Mite keywords
     BEGIN {
-        my $CALLER = "Mite::Trait::HasSuperclasses";
+        my ( $SHIM, $CALLER ) =
+          ( "Mite::Shim", "Mite::Trait::HasSuperclasses" );
         (
             *after,    *around,        *before,
             *field,    *has,           *param,
@@ -22,15 +23,15 @@
             package Mite::Shim;
             no warnings 'redefine';
             (
-                sub { __PACKAGE__->HANDLE_after( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_around( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_before( $CALLER, "role", @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
-                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { $SHIM->HANDLE_after( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, field => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { $SHIM->HANDLE_has( $CALLER, param => @_ ) },
                 sub { },
-                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
-                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "role", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
             );
           };
     }

--- a/lib/Mite/Trait/HasSuperclasses.pm.mite.pm
+++ b/lib/Mite/Trait/HasSuperclasses.pm.mite.pm
@@ -9,6 +9,33 @@
     our $MITE_SHIM    = "Mite::Shim";
     our $MITE_VERSION = "0.010001";
 
+    # Mite keywords
+    BEGIN {
+        my $CALLER = "Mite::Trait::HasSuperclasses";
+        (
+            *after,    *around,        *before,
+            *field,    *has,           *param,
+            *requires, *signature_for, *with
+          )
+          = do {
+
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { __PACKAGE__->HANDLE_after( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_around( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_before( $CALLER, "role", @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, field => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, has   => @_ ) },
+                sub { __PACKAGE__->HANDLE_has( $CALLER, param => @_ ) },
+                sub { },
+                sub { __PACKAGE__->HANDLE_signature_for( $CALLER, @_ ) },
+                sub { __PACKAGE__->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
+
+    # Mite imports
     BEGIN {
         require Scalar::Util;
         *STRICT  = \&Mite::Shim::STRICT;

--- a/lib/Mite/Trait/HasSuperclasses.pm.mite.pm
+++ b/lib/Mite/Trait/HasSuperclasses.pm.mite.pm
@@ -121,7 +121,8 @@
         my $shim = "Mite::Shim";
         for my $modifier_rule (@METHOD_MODIFIERS) {
             my ( $modification, $names, $coderef ) = @$modifier_rule;
-            $shim->$modification( $target, $names, $coderef );
+            my $handler = "HANDLE_$modification";
+            $shim->$handler( $target, "class", $names, $coderef );
         }
 
         return;

--- a/t/Mite-Shim/lib/Foo.pm.mite.pm
+++ b/t/Mite-Shim/lib/Foo.pm.mite.pm
@@ -1,35 +1,141 @@
 {
-package Foo;
-use strict;
-use warnings;
 
+    package Foo;
+    use strict;
+    use warnings;
+    no warnings qw( once void );
 
-sub new {
-    my $class = shift;
-    my %args  = @_;
+    our $USES_MITE    = "Mite::Class";
+    our $MITE_SHIM    = "Mite::Shim";
+    our $MITE_VERSION = "0.010001";
 
-    my $self = bless \%args, $class;
+    # Mite keywords
+    BEGIN {
+        my ( $SHIM, $CALLER ) = ( "Mite::Shim", "Foo" );
+        ( *after, *around, *before, *extends, *has, *signature_for, *with ) =
+          do {
 
-    $self->{thing} //= q[23];
+            package Mite::Shim;
+            no warnings 'redefine';
+            (
+                sub { $SHIM->HANDLE_after( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_around( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_before( $CALLER, "class", @_ ) },
+                sub { },
+                sub { $SHIM->HANDLE_has( $CALLER, has => @_ ) },
+                sub { $SHIM->HANDLE_signature_for( $CALLER, "class", @_ ) },
+                sub { $SHIM->HANDLE_with( $CALLER, @_ ) },
+            );
+          };
+    }
 
-    return $self;
-}
+    # Gather metadata for constructor and destructor
+    sub __META__ {
+        no strict 'refs';
+        no warnings 'once';
+        my $class = shift;
+        $class = ref($class) || $class;
+        my $linear_isa = mro::get_linear_isa($class);
+        return {
+            BUILD => [
+                map { ( *{$_}{CODE} ) ? ( *{$_}{CODE} ) : () }
+                map { "$_\::BUILD" } reverse @$linear_isa
+            ],
+            DEMOLISH => [
+                map   { ( *{$_}{CODE} ) ? ( *{$_}{CODE} ) : () }
+                  map { "$_\::DEMOLISH" } @$linear_isa
+            ],
+            HAS_BUILDARGS        => $class->can('BUILDARGS'),
+            HAS_FOREIGNBUILDARGS => $class->can('FOREIGNBUILDARGS'),
+        };
+    }
 
-if( !$ENV{MITE_PURE_PERL} && eval { require Class::XSAccessor } ) {
-Class::XSAccessor->import(
-    accessors => { q[thing] => q[thing] }
-);
+    # Standard Moose/Moo-style constructor
+    sub new {
+        my $class = ref( $_[0] ) ? ref(shift) : shift;
+        my $meta  = ( $Mite::META{$class} ||= $class->__META__ );
+        my $self  = bless {}, $class;
+        my $args =
+            $meta->{HAS_BUILDARGS}
+          ? $class->BUILDARGS(@_)
+          : { ( @_ == 1 ) ? %{ $_[0] } : @_ };
+        my $no_build = delete $args->{__no_BUILD__};
 
-}
-else {
-*thing = sub {
-    # This is hand optimized.  Yes, even adding
-    # return will slow it down.
-    @_ > 1 ? $_[0]->{ q[thing] } = $_[1]
-           : $_[0]->{ q[thing] };
-}
+        # Attribute thing
+        # has declaration, file t/Mite-Shim/lib/Foo.pm, line 5
+        $self->{"thing"} =
+          ( exists( $args->{"thing"} ) ? $args->{"thing"} : "23" );
 
-}
+        # Call BUILD methods
+        $self->BUILDALL($args) if ( !$no_build and @{ $meta->{BUILD} || [] } );
 
-1;
+        # Unrecognized parameters
+        my @unknown = grep not(/\Athing\z/), keys %{$args};
+        @unknown
+          and Mite::Shim::croak(
+            "Unexpected keys in constructor: " . join( q[, ], sort @unknown ) );
+
+        return $self;
+    }
+
+    # Used by constructor to call BUILD methods
+    sub BUILDALL {
+        my $class = ref( $_[0] );
+        my $meta  = ( $Mite::META{$class} ||= $class->__META__ );
+        $_->(@_) for @{ $meta->{BUILD} || [] };
+    }
+
+    # Destructor should call DEMOLISH methods
+    sub DESTROY {
+        my $self  = shift;
+        my $class = ref($self) || $self;
+        my $meta  = ( $Mite::META{$class} ||= $class->__META__ );
+        my $in_global_destruction =
+          defined ${^GLOBAL_PHASE}
+          ? ${^GLOBAL_PHASE} eq 'DESTRUCT'
+          : Devel::GlobalDestruction::in_global_destruction();
+        for my $demolisher ( @{ $meta->{DEMOLISH} || [] } ) {
+            my $e = do {
+                local ( $?, $@ );
+                eval { $demolisher->( $self, $in_global_destruction ) };
+                $@;
+            };
+            no warnings 'misc';    # avoid (in cleanup) warnings
+            die $e if $e;          # rethrow
+        }
+        return;
+    }
+
+    my $__XS = !$ENV{MITE_PURE_PERL}
+      && eval { require Class::XSAccessor; Class::XSAccessor->VERSION("1.19") };
+
+    # Accessors for thing
+    # has declaration, file t/Mite-Shim/lib/Foo.pm, line 5
+    if ($__XS) {
+        Class::XSAccessor->import(
+            chained     => 1,
+            "accessors" => { "thing" => "thing" },
+        );
+    }
+    else {
+        *thing = sub {
+            @_ > 1 ? do { $_[0]{"thing"} = $_[1]; $_[0]; } : ( $_[0]{"thing"} );
+        };
+    }
+
+    # See UNIVERSAL
+    sub DOES {
+        my ( $self, $role ) = @_;
+        our %DOES;
+        return $DOES{$role} if exists $DOES{$role};
+        return 1            if $role eq __PACKAGE__;
+        return $self->SUPER::DOES($role);
+    }
+
+    # Alias for Moose/Moo-compatibility
+    sub does {
+        shift->DOES(@_);
+    }
+
+    1;
 }


### PR DESCRIPTION
Defines the Mite keywords in the .mite.pm files instead of in the shim. (Though many keywords still use callbacks to the Shim.)